### PR TITLE
feat: add options to control new tab placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Chromium extension that ensures new tabs open to the right of the current active tab.
 
+An options page allows customizing the position of new tabs (after the active tab,
+at the start, or at the end) and whether a tab opened from within a tab group
+should instead appear after the entire group.
+
 ## Development
 
 1. Load `manifest.json` and `background.js` as an unpacked extension in Chrome or any Chromium-based browser.
@@ -12,5 +16,5 @@ Chromium extension that ensures new tabs open to the right of the current active
 To create a distributable archive:
 
 ```bash
-zip -r next-to-current-tab.zip manifest.json background.js README.md
+zip -r next-to-current-tab.zip manifest.json background.js options.html options.js README.md
 ```

--- a/background.js
+++ b/background.js
@@ -1,15 +1,36 @@
-const lastActiveIndex = {};
+const lastActiveTab = {};
 
 chrome.tabs.onActivated.addListener((activeInfo) => {
   chrome.tabs.get(activeInfo.tabId, (tab) => {
     if (chrome.runtime.lastError) return;
-    lastActiveIndex[tab.windowId] = tab.index;
+    lastActiveTab[tab.windowId] = { index: tab.index, groupId: tab.groupId };
   });
 });
 
 chrome.tabs.onCreated.addListener((tab) => {
-  const index = lastActiveIndex[tab.windowId];
-  if (typeof index === 'number') {
-    chrome.tabs.move(tab.id, { index: index + 1 });
-  }
+  chrome.storage.sync.get({ position: 'after', avoidGroups: false }, (prefs) => {
+    const last = lastActiveTab[tab.windowId];
+
+    if (prefs.position === 'start') {
+      chrome.tabs.move(tab.id, { index: 0 });
+      return;
+    }
+
+    if (prefs.position === 'end') {
+      chrome.tabs.move(tab.id, { index: -1 });
+      return;
+    }
+
+    if (last && typeof last.index === 'number') {
+      if (prefs.avoidGroups && last.groupId >= 0) {
+        chrome.tabs.query({ groupId: last.groupId, windowId: tab.windowId }, (groupTabs) => {
+          const maxIndex = Math.max(...groupTabs.map((t) => t.index));
+          chrome.tabs.move(tab.id, { index: maxIndex + 1 });
+        });
+      } else {
+        chrome.tabs.move(tab.id, { index: last.index + 1 });
+      }
+    }
+  });
 });
+

--- a/manifest.json
+++ b/manifest.json
@@ -3,12 +3,16 @@
   "name": "Next to Current Tab",
   "version": "1.0.0",
   "description": "Always open new tabs next to the current active tab",
-  "permissions": ["tabs"],
+  "permissions": ["tabs", "storage"],
   "background": {
     "service_worker": "background.js"
   },
   "action": {
     "default_title": "Next to Current Tab"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
   }
 }
 

--- a/options.html
+++ b/options.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Next to Current Tab Options</title>
+</head>
+<body>
+  <div>
+    <label for="position">Position of new tab:</label>
+    <select id="position">
+      <option value="after">After active</option>
+      <option value="end">At end</option>
+      <option value="start">At start</option>
+    </select>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" id="avoidGroups"> Avoid tab groups
+    </label>
+  </div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,20 @@
+const positionSelect = document.getElementById('position');
+const avoidGroupsCheckbox = document.getElementById('avoidGroups');
+
+function saveOptions() {
+  chrome.storage.sync.set({
+    position: positionSelect.value,
+    avoidGroups: avoidGroupsCheckbox.checked,
+  });
+}
+
+function restoreOptions() {
+  chrome.storage.sync.get({ position: 'after', avoidGroups: false }, (items) => {
+    positionSelect.value = items.position;
+    avoidGroupsCheckbox.checked = items.avoidGroups;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', restoreOptions);
+positionSelect.addEventListener('change', saveOptions);
+avoidGroupsCheckbox.addEventListener('change', saveOptions);


### PR DESCRIPTION
## Summary
- add options page allowing users to select new-tab position and whether to avoid tab groups
- respect saved settings in background script
- document customization and update bundling instructions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a72168fcf8832194decbe520b3da51