### PR TITLE
Configure extension icons for browser and store

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ the group entirely.
 
 ## Bundling
 
-To create a distributable archive:
+To create a distributable archive that can be uploaded to the Chrome Web Store:
 
 ```bash
-zip -r next-to-current-tab.zip manifest.json background.js options.html options.js README.md
+zip -r next-to-current-tab.zip \
+  manifest.json background.js options.html options.css options.js \
+  icons images README.md
 ```
+
+The `icons/` directory contains the extension icons used by the browser and the
+Web Store listing. Marketing assets for the Chrome Web Store are located in the
+`images/` directory.

--- a/manifest.json
+++ b/manifest.json
@@ -7,8 +7,19 @@
   "background": {
     "service_worker": "background.js"
   },
+  "icons": {
+    "16": "icons/icon16.png",
+    "32": "icons/icon32.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
   "action": {
-    "default_title": "Next to Current Tab"
+    "default_title": "Next to Current Tab",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "32": "icons/icon32.png",
+      "48": "icons/icon48.png"
+    }
   },
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
## Summary
- add extension and toolbar icons to `manifest.json`
- document icons and Chrome Web Store assets in `README`

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f4d122ac832191b9c5de06793ff2