### PR TITLE
Add popup with quick tab behavior settings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
       "16": "icons/icon16.png",
       "32": "icons/icon32.png",
       "48": "icons/icon48.png"
-    }
+    },
+    "default_popup": "popup.html"
   },
   "options_ui": {
     "page": "options.html",

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,27 @@
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  margin: 0;
+  padding: 12px;
+  background: #fff;
+  min-width: 220px;
+}
+
+.field {
+  margin-bottom: 12px;
+}
+
+.label {
+  font-weight: 600;
+  margin-bottom: 4px;
+  display: block;
+}
+
+label {
+  display: block;
+  margin: 2px 0;
+}
+
+input[type="radio"] {
+  accent-color: #3f51b5;
+  margin-right: 6px;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Next to Current Tab</title>
+    <link rel="stylesheet" href="popup.css">
+  </head>
+  <body>
+    <div class="field">
+      <div class="label">New tab behaviour</div>
+      <label><input type="radio" name="position" value="after">After active</label>
+      <label><input type="radio" name="position" value="end">At end</label>
+      <label><input type="radio" name="position" value="start">At start</label>
+    </div>
+    <div class="field">
+      <div class="label">New tab behaviour in groups</div>
+      <label><input type="radio" name="groupPosition" value="after">After current one</label>
+      <label><input type="radio" name="groupPosition" value="first">First</label>
+      <label><input type="radio" name="groupPosition" value="last">Last</label>
+      <label><input type="radio" name="groupPosition" value="avoid">Avoid groups</label>
+    </div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,23 @@
+const positionRadios = document.querySelectorAll('input[name="position"]');
+const groupPositionRadios = document.querySelectorAll('input[name="groupPosition"]');
+
+function saveOptions() {
+  const position = document.querySelector('input[name="position"]:checked').value;
+  const groupPosition = document.querySelector('input[name="groupPosition"]:checked').value;
+  chrome.storage.sync.set({ position, groupPosition });
+}
+
+function restoreOptions() {
+  chrome.storage.sync.get({ position: 'after', groupPosition: 'after' }, (items) => {
+    const pos = document.querySelector(`input[name="position"][value="${items.position}"]`);
+    if (pos) pos.checked = true;
+    const grp = document.querySelector(`input[name="groupPosition"][value="${items.groupPosition}"]`);
+    if (grp) grp.checked = true;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  restoreOptions();
+  positionRadios.forEach((r) => r.addEventListener('change', saveOptions));
+  groupPositionRadios.forEach((r) => r.addEventListener('change', saveOptions));
+});


### PR DESCRIPTION
## Summary
- add popup with radio groups to set tab placement and group behavior
- store popup selections in sync storage
- wire extension action to open popup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f61c03288321a7caa059dbe2441a