### PR TITLE
refactor: align options page with popup settings

### DIFF
--- a/options.css
+++ b/options.css
@@ -27,19 +27,64 @@ h1 {
 
 .label {
   font-weight: 600;
+  padding: 6px 16px;
   margin-bottom: 4px;
   display: block;
+  color: #7b7c6e;
 }
 
-select {
-  margin-top: 4px;
-  padding: 6px 8px;
-  border-radius: 6px;
-  border: 1px solid #ccc;
-  width: 100%;
+label {
+  display: block;
+  padding: 6px 16px;
+  transition: background-color 0.1s ease;
 }
 
-input[type="checkbox"] {
-  accent-color: #3f51b5;
-  margin-right: 6px;
+label:hover {
+  background-color: #f0f0f0;
+}
+
+input[type="radio"] {
+  position: relative;
+  margin: 0 1rem 0 0;
+  cursor: pointer;
+}
+
+input[type="radio"]:before {
+  -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.45, 1.8, 0.5, 0.75);
+  -moz-transition: -moz-transform 0.4s cubic-bezier(0.45, 1.8, 0.5, 0.75);
+  transition: transform 0.4s cubic-bezier(0.45, 1.8, 0.5, 0.75);
+  -webkit-transform: scale(0, 0);
+  -moz-transform: scale(0, 0);
+  -ms-transform: scale(0, 0);
+  -o-transform: scale(0, 0);
+  transform: scale(0, 0);
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0.125rem;
+  z-index: 1;
+  width: 0.75rem;
+  height: 0.75rem;
+  background: #FB5B01;
+  border-radius: 50%;
+}
+
+input[type="radio"]:checked:before {
+  -webkit-transform: scale(1, 1);
+  -moz-transform: scale(1, 1);
+  -ms-transform: scale(1, 1);
+  -o-transform: scale(1, 1);
+  transform: scale(1, 1);
+}
+
+input[type="radio"]:after {
+  content: "";
+  position: absolute;
+  top: -0.25rem;
+  left: -0.125rem;
+  width: 1rem;
+  height: 1rem;
+  background: #fff;
+  border: 2px solid #BCB4A7;
+  border-radius: 50%;
 }

--- a/options.html
+++ b/options.html
@@ -9,21 +9,17 @@
     <div class="container">
       <h1>Next to Current Tab</h1>
       <div class="field">
-        <div class="label">Position of new tab</div>
-        <select id="position">
-          <option value="after">After active</option>
-          <option value="start">Open first</option>
-          <option value="end">Open last</option>
-        </select>
+        <div class="label">New tab behaviour</div>
+        <label><input type="radio" name="position" value="after">After active</label>
+        <label><input type="radio" name="position" value="start">Open first</label>
+        <label><input type="radio" name="position" value="end">Open last</label>
       </div>
       <div class="field">
-        <div class="label">Position of new tab in groups</div>
-        <select id="groupPosition">
-          <option value="after">After active</option>
-          <option value="first">Open first</option>
-          <option value="last">Open last</option>
-          <option value="avoid">Avoid groups</option>
-        </select>
+        <div class="label">New tab behaviour in groups</div>
+        <label><input type="radio" name="groupPosition" value="after">After active</label>
+        <label><input type="radio" name="groupPosition" value="first">Open first</label>
+        <label><input type="radio" name="groupPosition" value="last">Open last</label>
+        <label><input type="radio" name="groupPosition" value="avoid">Avoid groups</label>
       </div>
     </div>
     <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -1,20 +1,23 @@
-const positionSelect = document.getElementById('position');
-const groupPositionSelect = document.getElementById('groupPosition');
+const positionRadios = document.querySelectorAll('input[name="position"]');
+const groupPositionRadios = document.querySelectorAll('input[name="groupPosition"]');
 
 function saveOptions() {
-  chrome.storage.sync.set({
-    position: positionSelect.value,
-    groupPosition: groupPositionSelect.value,
-  });
+  const position = document.querySelector('input[name="position"]:checked').value;
+  const groupPosition = document.querySelector('input[name="groupPosition"]:checked').value;
+  chrome.storage.sync.set({ position, groupPosition });
 }
 
 function restoreOptions() {
   chrome.storage.sync.get({ position: 'after', groupPosition: 'after' }, (items) => {
-    positionSelect.value = items.position;
-    groupPositionSelect.value = items.groupPosition;
+    const pos = document.querySelector(`input[name="position"][value="${items.position}"]`);
+    if (pos) pos.checked = true;
+    const grp = document.querySelector(`input[name="groupPosition"][value="${items.groupPosition}"]`);
+    if (grp) grp.checked = true;
   });
 }
 
-document.addEventListener('DOMContentLoaded', restoreOptions);
-positionSelect.addEventListener('change', saveOptions);
-groupPositionSelect.addEventListener('change', saveOptions);
+document.addEventListener('DOMContentLoaded', () => {
+  restoreOptions();
+  positionRadios.forEach((r) => r.addEventListener('change', saveOptions));
+  groupPositionRadios.forEach((r) => r.addEventListener('change', saveOptions));
+});


### PR DESCRIPTION
## Summary
- replace dropdowns in options page with radio buttons matching popup
- reuse popup logic to save and restore option selections
- apply popup radio button styling to options page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a80066073083219ec164889a5ab2ce