### PR TITLE
Track last active tab for bookmark tabs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "New Tab Order",
   "version": "1.0.0",
   "description": "New tabs open exactly where you need them. With special control over tab groups.",
-  "permissions": ["storage"],
+  "permissions": ["storage", "tabs"],
   "background": {
     "service_worker": "background.js"
   },


### PR DESCRIPTION
## Summary
- Keep track of the last active tab per window
- Use cached active tab when creating new tabs without an opener
- Request the `tabs` permission required by the new logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afd7c3f4c48321954c5671fd98ca1d