### PR TITLE
Preserve tab groups for restored sessions

### DIFF
--- a/background.js
+++ b/background.js
@@ -45,6 +45,13 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 });
 
 chrome.tabs.onCreated.addListener((tab) => {
+  // When Chrome restores a previous session it re-creates tabs in a discarded
+  // state without an opener. Moving such tabs would break their original
+  // order and tab group assignment, so skip handling for them.
+  if (!tab.openerTabId && tab.discarded) {
+    return;
+  }
+
   const parentTabId = tab.openerTabId;
   const winId = tab.windowId;
 


### PR DESCRIPTION
## Summary
- avoid moving tabs that are restored in discarded state to keep their original order and groups

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be55fa178c8321b1b4537b64e86d69