### PR TITLE
Preserve tab groups for restored sessions

### DIFF
--- a/background.js
+++ b/background.js
@@ -45,6 +45,13 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 });
 
 chrome.tabs.onCreated.addListener((tab) => {
+  // When Chrome restores a previous session it re-creates tabs without an
+  // opener and often in a discarded state. Moving such tabs would break their
+  // original order and tab group assignment, so skip handling for them.
+  if (!tab.openerTabId && (tab.discarded || tab.sessionId)) {
+    return;
+  }
+
   const parentTabId = tab.openerTabId;
   const winId = tab.windowId;
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "New Tab Order",
   "version": "1.0.2",
   "description": "New tabs open exactly where you need them. With special control over tab groups.",
-  "permissions": ["storage"],
+  "permissions": ["storage", "sessions"],
   "background": {
     "service_worker": "background.js"
   },


### PR DESCRIPTION
## Summary
- avoid moving tabs restored from a previous session by checking for a sessionId
- request `sessions` permission to read restored tab info

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be55fa178c8321b1b4537b64e86d69